### PR TITLE
add ending / to temp path after adding job name.

### DIFF
--- a/src/helpers/glue.helper.ts
+++ b/src/helpers/glue.helper.ts
@@ -34,7 +34,7 @@ export class GlueHelper {
       this.config.tempDirS3Prefix = this.config.tempDirS3Prefix.split("/").filter(a=>a!="").join("/");
       jobTempDirS3Prefix += `/${this.config.tempDirS3Prefix}`;
     }
-    jobTempDirS3Prefix += `/${glueJob.name}`;
+    jobTempDirS3Prefix += `/${glueJob.name}/`;
 
     glueJob.DefaultArguments.tempDir = {
       "Fn::Join": ["", ["s3://", jobTempDirBucket, jobTempDirS3Prefix]],


### PR DESCRIPTION
From AWS ...

Temporary path
Working directory. Path must be in the form s3://bucket/prefix/path/. It must end with a slash (/) and not include any files.